### PR TITLE
CDP-3039 - JsonFlatten - Correct bug with datatype inference sometimes failing to infer escaped JSON Strings

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtils.java
@@ -23,7 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.core.JsonProcessingException;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
@@ -191,6 +194,13 @@ public class SchematizationUtils {
       }
       return INT64;
     } else if (value.isTextual()) {
+      try {
+        if (new ObjectMapper().readTree(value.textValue()).isObject() ) {
+          return STRUCT;
+        } else {
+          return STRING;
+        }
+      } catch(JsonProcessingException ignored) {}
       return STRING;
     } else if (value.isBoolean()) {
       return BOOLEAN;

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtilsTest.java
@@ -2,15 +2,15 @@ package com.snowflake.kafka.connector.internal.streaming;
 
 import com.snowflake.kafka.connector.internal.TestUtils;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import com.snowflake.kafka.connector.records.RecordService;
+import com.snowflake.kafka.connector.records.SnowflakeJsonConverter;
+import com.snowflake.kafka.connector.records.SnowflakeJsonSchema;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.core.JsonProcessingException;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 public class SchematizationUtilsTest {
-  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+//  @Rule public EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   @Test
   public void testFormatNames() {
@@ -41,27 +41,27 @@ public class SchematizationUtilsTest {
     Map<String, String> jsonMap = new HashMap<>();
     jsonMap.put(columnName, "value");
     SchemaAndValue schemaAndValue =
-        jsonConverter.toConnectData("topic", mapper.writeValueAsBytes(jsonMap));
+            jsonConverter.toConnectData("topic", mapper.writeValueAsBytes(jsonMap));
     SinkRecord recordWithoutSchema =
-        new SinkRecord(
-            "topic",
-            0,
-            null,
-            null,
-            schemaAndValue.schema(),
-            schemaAndValue.value(),
-            0,
-            System.currentTimeMillis(),
-            TimestampType.CREATE_TIME);
+            new SinkRecord(
+                    "topic",
+                    0,
+                    null,
+                    null,
+                    schemaAndValue.schema(),
+                    schemaAndValue.value(),
+                    0,
+                    System.currentTimeMillis(),
+                    TimestampType.CREATE_TIME);
 
     Map<String, String> columnToTypes =
-        SchematizationUtils.getColumnTypes(
-            recordWithoutSchema, Collections.singletonList(columnName));
+            SchematizationUtils.getColumnTypes(
+                    recordWithoutSchema, Collections.singletonList(columnName));
     Assert.assertEquals("VARCHAR", columnToTypes.get(columnName));
     // Get non-existing column name should return VARIANT data type
     columnToTypes =
-        SchematizationUtils.getColumnTypes(
-            recordWithoutSchema, Collections.singletonList("random"));
+            SchematizationUtils.getColumnTypes(
+                    recordWithoutSchema, Collections.singletonList("random"));
     Assert.assertEquals("VARIANT", columnToTypes.get("random"));
   }
 
@@ -72,25 +72,25 @@ public class SchematizationUtilsTest {
     converterConfig.put("schemas.enable", "true");
     converter.configure(converterConfig, false);
     SchemaAndValue schemaAndValue =
-        converter.toConnectData(
-            "topic", TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
+            converter.toConnectData(
+                    "topic", TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
     String columnName1 = "regionid";
     String columnName2 = "gender";
     SinkRecord recordWithoutSchema =
-        new SinkRecord(
-            "topic",
-            0,
-            null,
-            null,
-            schemaAndValue.schema(),
-            schemaAndValue.value(),
-            0,
-            System.currentTimeMillis(),
-            TimestampType.CREATE_TIME);
+            new SinkRecord(
+                    "topic",
+                    0,
+                    null,
+                    null,
+                    schemaAndValue.schema(),
+                    schemaAndValue.value(),
+                    0,
+                    System.currentTimeMillis(),
+                    TimestampType.CREATE_TIME);
 
     Map<String, String> columnToTypes =
-        SchematizationUtils.getColumnTypes(
-            recordWithoutSchema, Arrays.asList(columnName1, columnName2));
+            SchematizationUtils.getColumnTypes(
+                    recordWithoutSchema, Arrays.asList(columnName1, columnName2));
     Assert.assertEquals("VARCHAR", columnToTypes.get(columnName1));
     Assert.assertEquals("VARCHAR", columnToTypes.get(columnName2));
   }
@@ -132,5 +132,37 @@ public class SchematizationUtilsTest {
 //            SchematizationUtils.getColumnTypes(
 //                    recordWithoutSchema, Collections.singletonList("random"));
 //    Assert.assertEquals("VARIANT", columnToTypes.get("random"));
+  }
+// Integration test inc RecordService getProcessedRecord parsing
+//  Test Escaped JSON Document inferance
+  @Test
+  public void test_IntRS_InferEscapedJSONDocument() {
+    String value = "{\"payload\": \"{\\\"version\\\":\\\"0\\\",\\\"id\\\":\\\"44d7498a-f920-40b4-eff5-5ea8bf5579c2\\\",\\\"detail-type\\\":\\\"git_clone\\\",\\\"source\\\":\\\"github\\\",\\\"account\\\":\\\"123\\\",\\\"time\\\":\\\"2023-03-30T08:13:30Z\\\",\\\"region\\\":\\\"eu-west-1\\\",\\\"resources\\\":[],\\\"detail\\\":{\\\"action\\\":\\\"git.clone\\\",\\\"_document_id\\\":\\\"lR1EYOpB0kMt1g==\\\",\\\"actor_location\\\":{\\\"country_code\\\":\\\"IE\\\"},\\\"transport_protocol\\\":1,\\\"transport_protocol_name\\\":\\\"http\\\",\\\"user_agent\\\":\\\"git/2.38.4\\\",\\\"repository\\\":\\\"org/repo\\\",\\\"repo\\\":\\\"org/repo\\\",\\\"repository_public\\\":false,\\\"actor\\\":\\\"devops\\\",\\\"actor_id\\\":123,\\\"org\\\":\\\"org\\\",\\\"org_id\\\":123,\\\"business\\\":\\\"biz\\\",\\\"business_id\\\":123,\\\"user\\\":\\\"\\\",\\\"user_id\\\":0,\\\"hashed_token\\\":\\\"oWsDTN6d35W3HytkCsLnIh2Xv8Vss=\\\",\\\"token_id\\\":123,\\\"@timestamp\\\":1680164004588}}\"}";
+    SnowflakeJsonConverter jsonConverter = new SnowflakeJsonConverter();
+    byte[] valueContents = (value).getBytes(StandardCharsets.UTF_8);
+    SchemaAndValue schemaAndValue =
+            jsonConverter.toConnectData("topic", valueContents);
+
+    SinkRecord recordWithoutSchema =
+            new SinkRecord(
+                    "topic", 0, Schema.STRING_SCHEMA, "string", schemaAndValue.schema(), schemaAndValue.value(), 0);
+
+
+    RecordService rs = new RecordService();
+    rs.setNestDepth(2);
+    rs.setEnableSchematization(true);
+    try {
+      Map<String, Object> processedRecordForStreamingIngest = rs.getProcessedRecordForStreamingIngest(recordWithoutSchema);
+      recordWithoutSchema =
+              new SinkRecord(
+                      "topic", 0, Schema.STRING_SCHEMA, "string", null, processedRecordForStreamingIngest, 0);
+      Map<String, String> columnToTypes = SchematizationUtils.getColumnTypes(recordWithoutSchema, Collections.singletonList("PAYLOAD_DETAIL"));
+      assert Objects.equals(columnToTypes.get("PAYLOAD_DETAIL"), "VARIANT");
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+
+
+    assert true;
   }
 }


### PR DESCRIPTION
- Attempt to convert value to object during type inference
- Add integration test testing this test case + using RecordService to parse the record initially