### PR TITLE
Cherrypick commits from main SF branch to enable config validation to use specified SF Role

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -133,7 +133,7 @@
                             </confluentControlCenterIntegration>
                             <singleMessageTransforms>false
                             </singleMessageTransforms>
-                            <supportedEncodings>UTF-8</supportedEncodings>
+                            <supportedEncodings>any</supportedEncodings>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -1,7 +1,9 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
@@ -106,13 +108,27 @@ class InternalUtils {
   }
 
   /**
+   * Use this function if you want to create properties from user provided Snowflake kafka connector
+   * config. It assumes the caller wants to use this Property for Snowpipe based Kafka Connector.
+   *
+   * @param conf User provided kafka connector config
+   * @param sslEnabled is sslEnabled?
+   * @return Properties object which will be passed down to JDBC connection
+   */
+  static Properties createProperties(Map<String, String> conf, boolean sslEnabled) {
+    return createProperties(conf, sslEnabled, IngestionMethodConfig.SNOWPIPE);
+  }
+
+  /**
    * create a properties for snowflake connection
    *
    * @param conf a map contains all parameters
    * @param sslEnabled if ssl is enabled
+   * @param ingestionMethodConfig which ingestion method is provided.
    * @return a Properties instance
    */
-  static Properties createProperties(Map<String, String> conf, boolean sslEnabled) {
+  static Properties createProperties(
+      Map<String, String> conf, boolean sslEnabled, IngestionMethodConfig ingestionMethodConfig) {
     Properties properties = new Properties();
 
     // decrypt rsa key
@@ -161,6 +177,25 @@ class InternalUtils {
     }
     // put values for optional parameters
     properties.put(JDBC_SESSION_KEEP_ALIVE, "true");
+
+    /**
+     * Behavior change in JDBC release 3.13.25
+     *
+     * @see <a href="https://community.snowflake.com/s/article/JDBC-Driver-Release-Notes">Snowflake
+     *     Documentation Release Notes </a>
+     */
+    properties.put(SFSessionProperty.ALLOW_UNDERSCORES_IN_HOST.getPropertyKey(), "true");
+
+    if (ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE_STREAMING) {
+      final String providedSFRoleInConfig = conf.get(Utils.SF_ROLE);
+      if (!Strings.isNullOrEmpty(providedSFRoleInConfig)) {
+        LOGGER.info("Using provided role {} for JDBC connection.", providedSFRoleInConfig);
+        properties.put(SFSessionProperty.ROLE, providedSFRoleInConfig);
+      } else {
+        LOGGER.info(
+            "Snowflake role is not provided, user's default role will be used for JDBC connection");
+      }
+    }
 
     // required parameter check
     if (!properties.containsKey(JDBC_PRIVATE_KEY)) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -1,7 +1,7 @@
 package com.snowflake.kafka.connector.internal;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.PROVIDER_CONFIG;
-
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import java.util.Map;
@@ -18,6 +18,8 @@ public class SnowflakeConnectionServiceFactory {
     private SnowflakeURL url;
     private String connectorName;
     private String taskID = "-1";
+
+    private IngestionMethodConfig ingestionMethodConfig;
 
     // whether kafka is hosted on premise or on confluent cloud.
     // This info is provided in the connector configuration
@@ -55,7 +57,6 @@ public class SnowflakeConnectionServiceFactory {
         throw SnowflakeErrors.ERROR_0017.getException();
       }
       this.url = new SnowflakeURL(conf.get(Utils.SF_URL));
-      this.prop = InternalUtils.createProperties(conf, this.url.sslEnabled());
       this.kafkaProvider =
           SnowflakeSinkConnectorConfig.KafkaProvider.of(conf.get(PROVIDER_CONFIG)).name();
       // TODO: Ideally only one property is required, but because we dont pass it around in JDBC and
@@ -65,6 +66,9 @@ public class SnowflakeConnectionServiceFactory {
       // be decoupled
       this.proxyProperties = InternalUtils.generateProxyParametersIfRequired(conf);
       this.connectorName = conf.get(Utils.NAME);
+      this.ingestionMethodConfig = IngestionMethodConfig.determineIngestionMethod(conf);
+      this.prop =
+          InternalUtils.createProperties(conf, this.url.sslEnabled(), ingestionMethodConfig);
       return this;
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/IngestionMethodConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/IngestionMethodConfig.java
@@ -1,55 +1,82 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import java.util.Locale;
+import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 
 /**
  * Enum representing the allowed values for config {@link
  * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#INGESTION_METHOD_OPT}
+ *
+ * <p>NOTE: Please do not change ordering of this Enums, please append to the end.
  */
 public enum IngestionMethodConfig {
 
-  /* Default Way of ingestion */
-  SNOWPIPE,
+    /* Default Way of ingestion */
+    SNOWPIPE,
 
-  /* Snowpipe streaming which doesnt convert records to intermediate files (from client perspective) */
-  SNOWPIPE_STREAMING,
-  ;
+    /* Snowpipe streaming which doesnt convert records to intermediate files (from client perspective) */
+    SNOWPIPE_STREAMING,
+    ;
 
-  /* Validator to validate snowflake.ingestion.method values */
-  public static final ConfigDef.Validator VALIDATOR =
-      new ConfigDef.Validator() {
-        private final ConfigDef.ValidString validator =
-            ConfigDef.ValidString.in(IngestionMethodConfig.allIngestionTypes());
+    /* Validator to validate snowflake.ingestion.method values */
+    public static final ConfigDef.Validator VALIDATOR =
+            new ConfigDef.Validator() {
+                private final ConfigDef.ValidString validator =
+                        ConfigDef.ValidString.in(IngestionMethodConfig.allIngestionTypes());
 
-        @Override
-        public void ensureValid(String name, Object value) {
-          if (value instanceof String) {
-            value = ((String) value).toLowerCase(Locale.ROOT);
-          }
-          validator.ensureValid(name, value);
+                @Override
+                public void ensureValid(String name, Object value) {
+                    if (value instanceof String) {
+                        value = ((String) value).toLowerCase(Locale.ROOT);
+                    }
+                    validator.ensureValid(name, value);
+                }
+
+                @Override
+                public String toString() {
+                    return validator.toString();
+                }
+            };
+
+    // All valid enum values
+    public static String[] allIngestionTypes() {
+        IngestionMethodConfig[] configs = values();
+        String[] result = new String[configs.length];
+
+        for (int i = 0; i < configs.length; i++) {
+            result[i] = configs[i].toString();
         }
 
-        @Override
-        public String toString() {
-          return validator.toString();
-        }
-      };
-
-  // All valid enum values
-  public static String[] allIngestionTypes() {
-    IngestionMethodConfig[] configs = values();
-    String[] result = new String[configs.length];
-
-    for (int i = 0; i < configs.length; i++) {
-      result[i] = configs[i].toString();
+        return result;
     }
 
-    return result;
-  }
+    /**
+     * Returns the Ingestion Method found in User Configuration for Snowflake Kafka Connector.
+     *
+     * <p>Default is always {@link IngestionMethodConfig#SNOWPIPE} unless an invalid value is passed
+     * which results in exception.
+     */
+    public static IngestionMethodConfig determineIngestionMethod(Map<String, String> inputConf) {
+        if (inputConf == null
+                || inputConf.isEmpty()
+                || !inputConf.containsKey(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT)) {
+            return IngestionMethodConfig.SNOWPIPE;
+        } else {
+            try {
+                return IngestionMethodConfig.valueOf(
+                        inputConf
+                                .get(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT)
+                                .toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ex) {
+                throw ex;
+            }
+        }
+    }
 
-  @Override
-  public String toString() {
-    return name().toLowerCase(Locale.ROOT);
-  }
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -743,4 +743,7 @@ public class TestUtils {
         .setProperties(clientProperties)
         .build();
   }
+  public static SnowflakeConnectionService getConnectionServiceForStreaming() {
+    return SnowflakeConnectionServiceFactory.builder().setProperties(getConfForStreaming()).build();
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 
 public class SnowflakeSinkServiceV2IT {
 
-  private SnowflakeConnectionService conn = TestUtils.getConnectionService();
+  private SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();
   private String table = TestUtils.randomTableName();
   private int partition = 0;
   private int partition2 = 1;


### PR DESCRIPTION
Connector config validation wasn't making use of the role specified in snowflake.role.name 

tested in QA:
<img width="1157" alt="image" src="https://github.com/cko-data-platform/snowflake-kafka-connector/assets/90192887/a1ac7eac-c43e-4ae9-a7e4-1cd4648bddd8">
