### PR TITLE
Fix Flattening Level 1

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtils.java
@@ -15,6 +15,7 @@ import static org.apache.kafka.connect.data.Schema.Type.INT64;
 import static org.apache.kafka.connect.data.Schema.Type.STRING;
 import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
@@ -148,13 +149,19 @@ public class SchematizationUtils {
     return parseColumnTypes(recordNode, columnNamesSet, schemaMap);
   }
 
+  public static Map<String, String> parseColumnTypesTest(JsonNode recordNode, Set<String> columnNamesSet, Map<String, String> schemaMap) {
+    return parseColumnTypes(recordNode, columnNamesSet, schemaMap);
+  }
+
+  @VisibleForTesting
   private static Map<String, String> parseColumnTypes(JsonNode recordNode, Set<String> columnNamesSet, Map<String, String> schemaMap) {
     Map<String, String> columnToType = new HashMap<>();
     Iterator<Map.Entry<String, JsonNode>> fields = recordNode.fields();
     while (fields.hasNext()) {
       Map.Entry<String, JsonNode> field = fields.next();
       String colName = Utils.quoteNameIfNeeded(field.getKey());
-      if (columnNamesSet.contains(field.getKey())) {
+
+      if (columnNamesSet.contains(colName)) {
         String type;
         if (schemaMap.isEmpty()) {
           // No schema associated with the record, we will try to infer it based on the data

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtils.java
@@ -15,7 +15,6 @@ import static org.apache.kafka.connect.data.Schema.Type.INT64;
 import static org.apache.kafka.connect.data.Schema.Type.STRING;
 import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
@@ -149,11 +148,6 @@ public class SchematizationUtils {
     return parseColumnTypes(recordNode, columnNamesSet, schemaMap);
   }
 
-  public static Map<String, String> parseColumnTypesTest(JsonNode recordNode, Set<String> columnNamesSet, Map<String, String> schemaMap) {
-    return parseColumnTypes(recordNode, columnNamesSet, schemaMap);
-  }
-
-  @VisibleForTesting
   private static Map<String, String> parseColumnTypes(JsonNode recordNode, Set<String> columnNamesSet, Map<String, String> schemaMap) {
     Map<String, String> columnToType = new HashMap<>();
     Iterator<Map.Entry<String, JsonNode>> fields = recordNode.fields();

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -627,7 +627,7 @@ public class TopicPartitionChannel {
     return Failsafe.with(reopenChannelFallbackExecutorForInsertRows)
         .get(
             new InsertRowsApiResponseSupplier(
-                this.channel, buffer, this.enableSchemaEvolution, this.conn, this.nestDepth > 1, nestColExcl));
+                this.channel, buffer, this.enableSchemaEvolution, this.conn, this.nestDepth > 0, nestColExcl));
   }
 
   /** Invokes the API given the channel and streaming Buffer. */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -726,7 +726,7 @@ public class TopicPartitionChannel {
                         this.channel.getTableName(),
                         nonNullableColumns,
                         extraColNames,
-                        new SinkRecord(unflattenedRec.topic(), unflattenedRec.kafkaPartition(), unflattenedRec.keySchema(), unflattenedRec.key(), unflattenedRec.valueSchema(), unflattenedRec.get(idx), unflattenedRec.kafkaOffset(),
+                        new SinkRecord(unflattenedRec.topic(), unflattenedRec.kafkaPartition(), unflattenedRec.keySchema(), unflattenedRec.key(), unflattenedRec.valueSchema(), records.get(idx), unflattenedRec.kafkaOffset(),
                                 unflattenedRec.timestamp(), unflattenedRec.timestampType()));
               }
 //                Run through the records until we apply changes

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -690,6 +690,7 @@ public class TopicPartitionChannel {
           InsertValidationResponse response =
               this.channel.insertRow(records.get(idx), Long.toString(offsets.get(idx)));
           if (response.hasErrors()) {
+            LOGGER.info("MJCLOG2 Tried to insert {} ||| {}  but failed", records.get(idx), idx);
             LOGGER.info("[INSERT-ERROR] {}", response.getInsertErrors().get(0).getMessage());
             InsertValidationResponse.InsertError insertError = response.getInsertErrors().get(0);
             List<String> extraColNames = insertError.getExtraColNames();
@@ -717,7 +718,7 @@ public class TopicPartitionChannel {
                         extraColNames,
                         new SinkRecord(unflattenedRec.topic(), unflattenedRec.kafkaPartition(), unflattenedRec.keySchema(), unflattenedRec.key(), unflattenedRec.valueSchema(), records.get(idx), unflattenedRec.kafkaOffset(),
                                 unflattenedRec.timestamp(), unflattenedRec.timestampType()));
-              } else if (this.nestDepth == 1) {
+              } else {
                 // covers the case where nestDepth = 1, so we don't want to flatten further
                 SinkRecord unflattenedRec = this.insertRowsStreamingBuffer.getSinkRecord(originalSinkRecordIdx);
                 changesApplied = SchematizationUtils.evolveSchemaIfNeeded(
@@ -727,14 +728,6 @@ public class TopicPartitionChannel {
                         extraColNames,
                         new SinkRecord(unflattenedRec.topic(), unflattenedRec.kafkaPartition(), unflattenedRec.keySchema(), unflattenedRec.key(), unflattenedRec.valueSchema(), unflattenedRec.value(), unflattenedRec.kafkaOffset(),
                                 unflattenedRec.timestamp(), unflattenedRec.timestampType()));
-              } else {
-                changesApplied = SchematizationUtils.evolveSchemaIfNeeded(
-                        this.conn,
-                        this.channel.getTableName(),
-                        nonNullableColumns,
-                        extraColNames,
-                        this.insertRowsStreamingBuffer.getSinkRecord(originalSinkRecordIdx)
-                );
               }
 //                Run through the records until we apply changes
 //                This is needed for cases where we're finding new cols

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -726,7 +726,7 @@ public class TopicPartitionChannel {
                         this.channel.getTableName(),
                         nonNullableColumns,
                         extraColNames,
-                        new SinkRecord(unflattenedRec.topic(), unflattenedRec.kafkaPartition(), unflattenedRec.keySchema(), unflattenedRec.key(), unflattenedRec.valueSchema(), unflattenedRec.value(), unflattenedRec.kafkaOffset(),
+                        new SinkRecord(unflattenedRec.topic(), unflattenedRec.kafkaPartition(), unflattenedRec.keySchema(), unflattenedRec.key(), unflattenedRec.valueSchema(), unflattenedRec.get(idx), unflattenedRec.kafkaOffset(),
                                 unflattenedRec.timestamp(), unflattenedRec.timestampType()));
               }
 //                Run through the records until we apply changes

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -705,6 +705,8 @@ public class TopicPartitionChannel {
               finalResponse.addError(insertError);
             } else {
               boolean changesApplied;
+              // Instead of using the first row in buffer to calculate whether to evolve the schema, we use the current record.
+              // This allows us to move through the buffer until we've resolved all conflicts with the Snowflake table schema and recordSchema.
               SinkRecord unflattenedRec = this.insertRowsStreamingBuffer.getSinkRecord(originalSinkRecordIdx);
               changesApplied = SchematizationUtils.evolveSchemaIfNeeded(
                         this.conn,

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -725,7 +725,7 @@ public class TopicPartitionChannel {
                         this.channel.getTableName(),
                         nonNullableColumns,
                         extraColNames,
-                        new SinkRecord(unflattenedRec.topic(), unflattenedRec.kafkaPartition(), unflattenedRec.keySchema(), unflattenedRec.key(), unflattenedRec.valueSchema(), unflattenedRec, unflattenedRec.kafkaOffset(),
+                        new SinkRecord(unflattenedRec.topic(), unflattenedRec.kafkaPartition(), unflattenedRec.keySchema(), unflattenedRec.key(), unflattenedRec.valueSchema(), unflattenedRec.value(), unflattenedRec.kafkaOffset(),
                                 unflattenedRec.timestamp(), unflattenedRec.timestampType()));
               } else {
                 changesApplied = SchematizationUtils.evolveSchemaIfNeeded(

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -352,7 +352,7 @@ public class RecordService {
       } else if (columnNode.isTextual()) {
         columnValue = columnNode.textValue();
         try {
-          if (MAPPER.readTree(columnNode.textValue()).isObject() && !this.nestColExcl.contains(columnName) && this.nestDepth > depth) {
+          if (MAPPER.readTree(columnNode.textValue()).isObject() && this.nestDepth > depth && !this.nestColExcl.contains(columnName)) {
             streamingIngestRow.putAll(this.getMapFromJsonNodeForStreamingIngest(MAPPER.readTree(columnNode.textValue()), sflColumnName, depth+1));
             continue;
           }

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -396,7 +396,7 @@ public class RecordService {
       } else if (columnNode.isTextual()) {
         columnValue = columnNode.textValue();
         try {
-          if (MAPPER.readTree(columnNode.textValue()).isObject() && !this.nestColExcl.contains(columnName)) {
+          if (MAPPER.readTree(columnNode.textValue()).isObject() && this.nestDepth > depth && !this.nestColExcl.contains(columnName)) {
             streamingIngestRow.putAll(this.getMapFromJsonNodeForStreamingIngest(MAPPER.readTree(columnNode.textValue()), sflColumnName, depth+1));
             continue;
           }

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -313,14 +313,14 @@ public class RecordService {
         streamingIngestRow.putAll(getMapFromJsonNodeForStreamingIngest(node));
       }
 
-      streamingIngestRow.put(TABLE_COLUMN_CONTENT, MAPPER.writeValueAsString(node));
+      streamingIngestRow.put(Utils.quoteNameIfNeeded(TABLE_COLUMN_CONTENT), MAPPER.writeValueAsString(node));
 
       if (metadataConfig.allFlag) {
-        streamingIngestRow.put(TABLE_COLUMN_METADATA, MAPPER.writeValueAsString(row.metadata));
+        streamingIngestRow.put(Utils.quoteNameIfNeeded(TABLE_COLUMN_METADATA), MAPPER.writeValueAsString(row.metadata));
       }
 
-      streamingIngestRow.put(TABLE_COLUMN_KAFKA_TIMESTAMP, MAPPER.writeValueAsString(new java.sql.Timestamp(System.currentTimeMillis())));
-      streamingIngestRow.put(TABLE_COLUMN_OFFSET, MAPPER.writeValueAsString((record.kafkaOffset())));
+      streamingIngestRow.put(Utils.quoteNameIfNeeded(TABLE_COLUMN_KAFKA_TIMESTAMP), MAPPER.writeValueAsString(new java.sql.Timestamp(System.currentTimeMillis())));
+      streamingIngestRow.put(Utils.quoteNameIfNeeded(TABLE_COLUMN_OFFSET), MAPPER.writeValueAsString((record.kafkaOffset())));
     }
     if (this.debugLog) {
       LOGGER.info("CAFLOG_DEBUGLOG_ROW - {} ~~~ {} ~~~ {} ~~~ {}", streamingIngestRow.toString(), record, record.kafkaOffset(), record.toString());

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -352,7 +352,7 @@ public class RecordService {
       } else if (columnNode.isTextual()) {
         columnValue = columnNode.textValue();
         try {
-          if (MAPPER.readTree(columnNode.textValue()).isObject() && !this.nestColExcl.contains(columnName)) {
+          if (MAPPER.readTree(columnNode.textValue()).isObject() && !this.nestColExcl.contains(columnName) && this.nestDepth > depth) {
             streamingIngestRow.putAll(this.getMapFromJsonNodeForStreamingIngest(MAPPER.readTree(columnNode.textValue()), sflColumnName, depth+1));
             continue;
           }

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -25,14 +25,7 @@ import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServic
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.logging.Logger;
 
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.core.JsonProcessingException;
@@ -415,7 +408,7 @@ public class RecordService {
       }
       // while the value is always dumped into a string, the Streaming Ingest SDK
       // will transform the value according to its type in the table
-      streamingIngestRow.put(sflColumnName, columnValue);
+      streamingIngestRow.put(Utils.quoteNameIfNeeded(sflColumnName), columnValue);
     }
 
     //        If we're dealing with nesting, we actually don't mind skipping here as we've seen cases of:

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtilsTest.java
@@ -5,11 +5,11 @@ import com.snowflake.kafka.connector.internal.TestUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-import com.snowflake.kafka.connector.records.RecordService;
-import com.snowflake.kafka.connector.records.SnowflakeJsonConverter;
-import com.snowflake.kafka.connector.records.SnowflakeJsonSchema;
+import com.snowflake.kafka.connector.records.*;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.core.JsonProcessingException;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -169,4 +169,39 @@ public class SchematizationUtilsTest {
 
     assert true;
   }
+
+
+  @Test
+  public void testParseColumnTypes() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+
+    SnowflakeConverter converter = new SnowflakeJsonConverter();
+
+    ObjectNode node = mapper.createObjectNode();
+
+    node.put("str", "test");
+
+    String json = "{ \"f1\" : \"v1\", \"f2\" : \"v2\", \"RECORD_METADATA\" : \"{\\\"f2\\\": \\\"v2\\\"}\" } ";
+    ObjectMapper objectMapper = new ObjectMapper();
+    SnowflakeRecordContent content = new SnowflakeRecordContent(objectMapper.readTree(json));
+
+    JsonNode[] jsonNodes = content.getData();
+
+    Set<String> columnNameSet = new HashSet<>();
+    columnNameSet.add(Utils.quoteNameIfNeeded("f1"));
+    columnNameSet.add(Utils.quoteNameIfNeeded("f2"));
+
+    // We don't want to columns that aren't quoted. We can safely ignore them.
+    columnNameSet.add("f3");
+    columnNameSet.add("FF5");
+
+    Map<String, String> emptySchemaMap = new HashMap<String, String>();
+
+    Map<String, String> got = SchematizationUtils.parseColumnTypesTest(jsonNodes[0], columnNameSet, emptySchemaMap);
+    System.out.println(got);
+
+    Assert.assertEquals(got.get(Utils.quoteNameIfNeeded("f1")), "VARCHAR");
+    Assert.assertEquals(got.get(Utils.quoteNameIfNeeded("f2")), "VARCHAR");
+  }
+
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SchematizationUtilsTest.java
@@ -169,39 +169,4 @@ public class SchematizationUtilsTest {
 
     assert true;
   }
-
-
-  @Test
-  public void testParseColumnTypes() throws Exception {
-    ObjectMapper mapper = new ObjectMapper();
-
-    SnowflakeConverter converter = new SnowflakeJsonConverter();
-
-    ObjectNode node = mapper.createObjectNode();
-
-    node.put("str", "test");
-
-    String json = "{ \"f1\" : \"v1\", \"f2\" : \"v2\", \"RECORD_METADATA\" : \"{\\\"f2\\\": \\\"v2\\\"}\" } ";
-    ObjectMapper objectMapper = new ObjectMapper();
-    SnowflakeRecordContent content = new SnowflakeRecordContent(objectMapper.readTree(json));
-
-    JsonNode[] jsonNodes = content.getData();
-
-    Set<String> columnNameSet = new HashSet<>();
-    columnNameSet.add(Utils.quoteNameIfNeeded("f1"));
-    columnNameSet.add(Utils.quoteNameIfNeeded("f2"));
-
-    // We don't want to columns that aren't quoted. We can safely ignore them.
-    columnNameSet.add("f3");
-    columnNameSet.add("FF5");
-
-    Map<String, String> emptySchemaMap = new HashMap<String, String>();
-
-    Map<String, String> got = SchematizationUtils.parseColumnTypesTest(jsonNodes[0], columnNameSet, emptySchemaMap);
-    System.out.println(got);
-
-    Assert.assertEquals(got.get(Utils.quoteNameIfNeeded("f1")), "VARCHAR");
-    Assert.assertEquals(got.get(Utils.quoteNameIfNeeded("f2")), "VARCHAR");
-  }
-
 }

--- a/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector.records;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.TestUtils;
@@ -275,7 +276,6 @@ public class RecordContentTest {
                 new SinkRecord(
                         topic, partition, Schema.STRING_SCHEMA, "string", sv.schema(), sv.value(), partition);
         Map<String, Object> got = service.getProcessedRecordForStreamingIngest(record);
-
     assert got.containsKey("\"NaMe\"");
     assert got.containsKey("\"ANSWER\"");
   }
@@ -374,8 +374,36 @@ public class RecordContentTest {
         // json string should not be enclosed in additional brackets
         // a non-double-quoted column name will be transformed into uppercase
 
-        assert got.get("outer_struct_name").equals("sf");
-        assert got.get("outer_struct_answer").equals("42");
+        System.out.println(got);
+
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_STRUCT_NAME")).equals("sf");
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_STRUCT_ANSWER")).equals("42");
+    }
+
+    @Test
+    public void testSchematizationNestedStringFieldLevelOne() throws JsonProcessingException {
+        RecordService service = new RecordService();
+        SnowflakeJsonConverter jsonConverter = new SnowflakeJsonConverter();
+
+        service.setEnableSchematization(true);
+        service.setNestDepth(1);
+        String value = "{\"name\":\"sf\",\"answer\":42}";
+        byte[] valueContents = (value).getBytes(StandardCharsets.UTF_8);
+        SchemaAndValue sv = jsonConverter.toConnectData(topic, valueContents);
+
+        SinkRecord record =
+                new SinkRecord(
+                        topic, partition, Schema.STRING_SCHEMA, "string", sv.schema(), sv.value(), partition);
+
+        Map<String, Object> got = service.getProcessedRecordForStreamingIngest(record);
+        // each field should be dumped into string format
+        // json string should not be enclosed in additional brackets
+        // a non-double-quoted column name will be transformed into uppercase
+
+        System.out.println(got);
+
+        assert got.get(Utils.quoteNameIfNeeded("NAME")).equals("sf");
+        assert got.get(Utils.quoteNameIfNeeded("ANSWER")).equals("42");
     }
 
     @Test
@@ -398,8 +426,8 @@ public class RecordContentTest {
         // json string should not be enclosed in additional brackets
         // a non-double-quoted column name will be transformed into uppercase
 
-        assert got.get("outer_2_struct_outer_struct_name").equals("sf");
-        assert got.get("outer_2_struct_outer_struct_answer").equals("42");
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_2_STRUCT_OUTER_STRUCT_NAME")).equals("sf");
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_2_STRUCT_OUTER_STRUCT_ANSWER")).equals("42");
     }
 
     @Test
@@ -422,9 +450,11 @@ public class RecordContentTest {
         // each field should be dumped into string format
         // json string should not be enclosed in additional brackets
         // a non-double-quoted column name will be transformed into uppercase
-        assert got.get("outer_struct_name").equals("sf");
-        assert got.get("outer_struct_answer").equals("42");
-        assert got.get("json_string_partitionkey_s").equals("MT942_BankStatement_2023013009063451.pgp");
+
+        System.out.println(got);
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_STRUCT_NAME")).equals("sf");
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_STRUCT_ANSWER")).equals("42");
+        assert got.get(Utils.quoteNameIfNeeded("JSON_STRING_PARTITIONKEY_S")).equals("MT942_BankStatement_2023013009063451.pgp");
     }
 
 
@@ -450,9 +480,9 @@ public class RecordContentTest {
         // json string should not be enclosed in additional brackets
         // a non-double-quoted column name will be transformed into uppercase
 
-        assert got.get("outer_struct_name").equals("sf");
-        assert got.containsKey("outer_struct_answer");
-        assert got.containsKey("outer_struct_exclme");
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_STRUCT_NAME")).equals("sf");
+        assert got.containsKey(Utils.quoteNameIfNeeded("OUTER_STRUCT_ANSWER"));
+        assert got.containsKey(Utils.quoteNameIfNeeded("OUTER_STRUCT_EXCLME"));
     }
 
     @Test
@@ -476,8 +506,8 @@ public class RecordContentTest {
         // json string should not be enclosed in additional brackets
         // a non-double-quoted column name will be transformed into uppercase
 
-        assert got.get("outer_2_struct_outer_struct_name").equals("sf");
-        assert got.get("outer_2_struct_outer_struct_answer").equals("42");
-        assert got.get("outer_2_struct_outer_struct_exclme").equals("{\"test\":1}");
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_2_STRUCT_OUTER_STRUCT_NAME")).equals("sf");
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_2_STRUCT_OUTER_STRUCT_ANSWER")).equals("42");
+        assert got.get(Utils.quoteNameIfNeeded("OUTER_2_STRUCT_OUTER_STRUCT_EXCLME")).equals("{\"test\":1}");
     }
 }

--- a/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
@@ -404,6 +404,7 @@ public class RecordContentTest {
 
         assert got.get(Utils.quoteNameIfNeeded("NAME")).equals("sf");
         assert got.get(Utils.quoteNameIfNeeded("ANSWER")).equals("42");
+        assert got.get(Utils.quoteNameIfNeeded("KAFKA_OFFSET")).equals("0");
     }
 
     @Test


### PR DESCRIPTION
There were two issues with the level one flattening:

Column names were incorrectly specified, Snowflake uses quoteNameIfNeeded to create new columns, wheras we were not using that function. Changed to use quoteNameIfNeeded.

We manually added additional columns when schematization is enabled (KAFKA_OFFSET, etc...) but we only added them to the record checked by Snowflake to add columns in the case where nestedDepth > 1. Changed to check always. 


## Testing

This was tested by creating a new Kafka Connector in dev https://lenses.cko-dev.ckotech.co/data/connectors/details/kafka-connect/DataPlatform-datahub_database_2-dbz-snowflake-sink. Additionally I ran our Snowflake sink integration tests which all pass. 